### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -1,4 +1,6 @@
 name: On pull request
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/wozut/publisher-web-service/security/code-scanning/1](https://github.com/wozut/publisher-web-service/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions granted to the `GITHUB_TOKEN`. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. Since the workflow does not appear to require write access to repository contents or pull requests, the minimal permission of `contents: read` is appropriate. This change should be made at the top of the `.github/workflows/on-pull-request.yaml` file, immediately after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
